### PR TITLE
Add typings/ to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,5 @@
 /coverage/
+/typings/
 /src/
 /.editorconfig
 /.gitignore


### PR DESCRIPTION
`typings/` folder should be in `.npmignore`.
